### PR TITLE
Issue 58

### DIFF
--- a/dmlex-v1.0/specification/modules/annotation/objectTypes/collocateMarker.xml
+++ b/dmlex-v1.0/specification/modules/annotation/objectTypes/collocateMarker.xml
@@ -29,6 +29,15 @@
   <itemizedlist>
     <title>Properties</title>
     <listitem>
+        <para><literal>startIndex</literal> (required). Non-negative integer. The index of the first character of the substring
+        according to the number of Unicode code points. The first character of the string has index
+        0. This property may be implicit if using in-line markup.</para>
+    </listitem>
+    <listitem>
+        <para><literal>endIndex</literal> (required). Non-negative integer. The index of the last character after the substring
+        according to the number of Unicode code points. This property may be implicit if using in-line markup</para>
+    </listitem>
+    <listitem>
       <para><literal>lemma</literal>
         <glossterm>optional</glossterm> (zero or one) and <glossterm>unique</glossterm>. Non-empty string. The lemmatized form of the
         collocate. An application can use it to provide a clickable link for the user to search for

--- a/dmlex-v1.0/specification/modules/annotation/objectTypes/headwordMarker.xml
+++ b/dmlex-v1.0/specification/modules/annotation/objectTypes/headwordMarker.xml
@@ -25,7 +25,20 @@
       <para><literal><olink targetptr="annotation_exampleTranslation">exampleTranslation</olink></literal></para>
     </listitem>
   </itemizedlist>
-  
+
+  <itemizedlist>
+    <title>Properties</title>
+    <listitem>
+        <para><literal>startIndex</literal> (required). Non-negative integer. The index of the first character of the substring
+        according to the number of Unicode code points. The first character of the string has index
+        0. This property may be implicit if using in-line markup.</para>
+    </listitem>
+    <listitem>
+        <para><literal>endIndex</literal> (required). Non-negative integer. The index of the last character after the substring
+        according to the number of Unicode code points. This property may be implicit if using in-line markup</para>
+    </listitem>
+  </itemizedlist> 
+   
   <example>
     <title>XML</title>
     <programlisting>

--- a/dmlex-v1.0/specification/modules/annotation/objectTypes/placeholderMarker.xml
+++ b/dmlex-v1.0/specification/modules/annotation/objectTypes/placeholderMarker.xml
@@ -23,7 +23,20 @@
       <para><literal><olink targetptr="annotation_headwordTranslation">headwordTranslation</olink></literal></para>
     </listitem>
   </itemizedlist>
-  
+
+  <itemizedlist>
+    <title>Properties</title>
+    <listitem>
+        <para><literal>startIndex</literal> (required). Non-negative integer. The index of the first character of the substring
+        according to the number of Unicode code points. The first character of the string has index
+        0. This property may be implicit if using in-line markup.</para>
+    </listitem>
+    <listitem>
+        <para><literal>endIndex</literal> (required). Non-negative integer. The index of the last character after the substring
+        according to the number of Unicode code points. This property may be implicit if using in-line markup</para>
+    </listitem>
+  </itemizedlist>
+ 
   <example>
     <title>XML</title>
     <programlisting>

--- a/dmlex-v1.0/specification/modules/values/extensions/lexicographicResource.xml
+++ b/dmlex-v1.0/specification/modules/values/extensions/lexicographicResource.xml
@@ -72,7 +72,7 @@
     "labelTypeTags": [...],
     "partOfSpeechTags": [...],
     "sourceIdentityTags": [...]
-    "transcriptionSchemeTag": [...]
+    "transcriptionSchemeTags": [...]
 }
     </programlisting>
   </example>


### PR DESCRIPTION
I added a description for `startIndex` and `endIndex` as properties.

This is the same as `listingOrder`, where it may not be used in some serializations, however it is still part of the model. This also clarifies that `startIndex` uses the number of Unicode characters (not byte index of a UTF-8 string)

Fixes #58 