### PR TITLE
Update RDF URL

### DIFF
--- a/dmlex-v1.0/specification/core/objectTypes/lexicographicResource.xml
+++ b/dmlex-v1.0/specification/core/objectTypes/lexicographicResource.xml
@@ -96,7 +96,7 @@
   <example>
     <title>RDF</title>
     <programlisting>
-@prefix dmlex: &lt;http://www.oasis-open.org/to-be-confirmed/dmlex&gt; .
+@prefix dmlex: &lt;https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#&gt; .
 
 &lt;#id&gt; a dmlex:LexicographicResource ;
   dmlex:title "..." ;

--- a/dmlex-v1.0/specification/examples/examples/source/0.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/0.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/1.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/1.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:folúsghlantóir-n a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/10.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/10.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/11.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/11.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:fómhar-n-1 a dmlex:Sense;

--- a/dmlex-v1.0/specification/examples/examples/source/12.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/12.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/13.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/13.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 [] a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/14.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/14.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/15.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/15.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/16.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/16.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/17.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/17.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/18.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/18.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/19.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/19.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:continue-studies a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/2.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/2.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:aardvark-noun a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/20.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/20.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:beat-up-1 a dmlex:Sense;

--- a/dmlex-v1.0/specification/examples/examples/source/21.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/21.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:autopsy-1 a dmlex:Sense;

--- a/dmlex-v1.0/specification/examples/examples/source/22.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/22.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:autopsy a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/23.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/23.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:cat-n a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/24.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/24.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/3.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/3.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:aardvark-noun a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/4.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/4.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:aardvark-noun a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/5.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/5.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/6.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/6.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/7.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/7.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:lexicon a dmlex:LexicographicResource;

--- a/dmlex-v1.0/specification/examples/examples/source/8.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/8.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:doctor-n a dmlex:Entry;

--- a/dmlex-v1.0/specification/examples/examples/source/9.rdf
+++ b/dmlex-v1.0/specification/examples/examples/source/9.rdf
@@ -1,7 +1,7 @@
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#>
+PREFIX dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#>
 PREFIX ex: <http://www.example.com/#>
 
 ex:treppenwitz a dmlex:Entry;

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-annotation.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-annotation.ttl
@@ -1,7 +1,7 @@
 ## The ontology for DMLex
 ## Author: John P. McCrae
 
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-controlled-values.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-controlled-values.ttl
@@ -1,7 +1,7 @@
 ## The ontology for DMLex
 ## Author: John P. McCrae
 
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-core.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-core.ttl
@@ -1,7 +1,7 @@
 ## The ontology for DMLex
 ## Author: John P. McCrae
 
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-etymology.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-etymology.ttl
@@ -1,7 +1,7 @@
 ## The ontology for DMLex - Etymology module
 ## Author: John P. McCrae
 
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-linking.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-linking.ttl
@@ -1,7 +1,7 @@
 ## The ontology for DMLex
 ## Author: John P. McCrae
 
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-xlingual.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-xlingual.ttl
@@ -1,7 +1,7 @@
 ## The ontology for DMLex
 ## Author: John P. McCrae
 
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex.shacl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex.shacl
@@ -1,7 +1,7 @@
 # This file was generated from dmlex.ttl by gen_shacl_from_rdf.py
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
-@prefix : <http://www.oasis-open.org/to-be-confirmed/dmlex-shacl#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
+@prefix : <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.shacl#> .
 
 
 :LexicographicResourceShape ;

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex.ttl
@@ -1,7 +1,7 @@
 ## The ontology for DMLex
 ## Author: John P. McCrae
 
-@prefix dmlex: <http://www.oasis-open.org/to-be-confirmed/dmlex#> .
+@prefix dmlex: <https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/dmlex-v1.0/specification/serializations/RDF/gen_docbook_from_rdf.py
+++ b/dmlex-v1.0/specification/serializations/RDF/gen_docbook_from_rdf.py
@@ -3,7 +3,7 @@ from rdflib.namespace import RDF, RDFS, OWL, URIRef
 from collections import defaultdict
 from rdflib.collection import Collection
 
-DMLEX = "http://www.oasis-open.org/to-be-confirmed/dmlex#"
+DMLEX = "https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#"
 
 def describe_property(g, property, file, restrictions):
     file.write(f"""

--- a/dmlex-v1.0/specification/serializations/RDF/gen_shacl_from_rdf.py
+++ b/dmlex-v1.0/specification/serializations/RDF/gen_shacl_from_rdf.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from rdflib.namespace import RDF, RDFS, OWL, URIRef
 from rdflib.collection import Collection
 
-DMLEX = "http://www.oasis-open.org/to-be-confirmed/dmlex#"
-DMLEX_SHACL = "http://www.oasis-open.org/to-be-confirmed/dmlex-shacl#"
+DMLEX = "https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#"
+DMLEX_SHACL = "https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.shacl#"
 
 def parse_rdf():
     g = rdflib.Graph()

--- a/dmlex-v1.0/specification/serializations/RDF/specification.xml
+++ b/dmlex-v1.0/specification/serializations/RDF/specification.xml
@@ -14,7 +14,7 @@
       <para>The RDF serialization used in this document follows the following principles</para>
       <itemizedlist>
           <listitem>
-            <para>The RDF serialization uses an vocabulary defined at the namespace <code>https://www.oasis-open.org/to-be-confirmed/dmlex</code>, al elements of the vocabulary are in this namespace</para>
+            <para>The RDF serialization uses an vocabulary defined at the namespace <code>https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#</code>, al elements of the vocabulary are in this namespace</para>
           </listitem>
           <listitem>
             <para>The vocabulary file provides RDF Schema and OWL axioms which implement the restrictions described by the data model. It also provides a linking to the <ulink url="https://www.w3.org/2016/05/ontolex/">OntoLex-Lemon</ulink> model. The ontology provides rules to infer an OntoLex-lemon model from DMLex data. This is achieved by means of subclass and subproperty axioms and so conversion can be performed by an OWL reasoner.</para>


### PR DESCRIPTION
URL for RDF namespace is now fixed at
https://docs.oasis-open.org/lexidma/dmlex/v1.0/schemas/RDF/dmlex.ttl#

Fixes #106 