### PR TITLE
Changs to the Etymology Module

### DIFF
--- a/dmlex-v1.0/specification/modules/etymology/extensions/sameAs.xml
+++ b/dmlex-v1.0/specification/modules/etymology/extensions/sameAs.xml
@@ -6,7 +6,7 @@
                          <!ENTITY % local.common.attrib "xml:base CDATA #IMPLIED" >
 ]>
 
-<section id="linking_sameAs">
+<section id="etymology_sameAs">
   <title>Extensions to <code>sameAs</code></title>
   <para>
     Extends the <code><olink targetptr="values_sameAs">sameAs</olink></code> object type

--- a/dmlex-v1.0/specification/modules/etymology/extensions/sameAs.xml
+++ b/dmlex-v1.0/specification/modules/etymology/extensions/sameAs.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+                         "http://www.docbook.org/xml/4.5/docbookx.dtd" [
+                         <!ENTITY % xinclude SYSTEM "../../../docbook/xinclude.mod" >
+                         %xinclude;
+                         <!ENTITY % local.common.attrib "xml:base CDATA #IMPLIED" >
+]>
+
+<section id="linking_sameAs">
+  <title>Extensions to <code>sameAs</code></title>
+  <para>
+    Extends the <code><olink targetptr="values_sameAs">sameAs</olink></code> object type
+    from the <olink targetptr="values">Controlled Values Module</olink>.
+  </para>
+  
+  <itemizedlist>
+    <title>Can additionally be a property of</title>
+    <listitem>
+      <para><literal><olink targetptr="linking_relationTypeTag">etymonLanguage</olink></literal></para>
+    </listitem>
+    <listitem>
+      <para><literal><olink targetptr="linking_memberRoletag">etymonType</olink></literal></para>
+    </listitem>
+  </itemizedlist>
+  
+  <example>
+    <title>Relational database</title>
+    <graphic fileref="modules/linking/databaseDiagrams/sameAs.svg" contentwidth="16cm"/>
+  </example>
+  
+</section>

--- a/dmlex-v1.0/specification/modules/etymology/objectTypes/etymon.xml
+++ b/dmlex-v1.0/specification/modules/etymology/objectTypes/etymon.xml
@@ -45,11 +45,6 @@
                 <glossterm>required</glossterm> (one or more) and <glossterm>unique</glossterm>.</para>
         </listitem>
         <listitem>
-            <para><literal>translation</literal>
-                <glossterm>optional</glossterm> (zero or one). Normalised string. A translation or
-                gloss of the etymon in the language of the lexicographic resource.</para>
-        </listitem>
-        <listitem>
             <para><literal>listingOrder</literal>
                 <glossterm>required</glossterm> (exactly one). Number. The position of this origin
                 among other origins listed in the etymology. This can be implicit from the

--- a/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonLanguage.xml
+++ b/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonLanguage.xml
@@ -32,6 +32,10 @@
         <glossterm>optional</glossterm> (zero or one). Normalised string. The name of the etymon
         language, in the language of the lexicographic resource.</para>
     </listitem>
+    <listitem>
+      <para><literal><olink targetptr="linking_sameAs">sameAs</olink></literal>
+        <glossterm>optional</glossterm> (zero or more).</para>
+    </listitem>
   </itemizedlist>
   
   <note>
@@ -48,6 +52,7 @@
         <programlisting>
 &lt;etymonLanguage langCode="..."&gt;
   &lt;displayName&gt;...&lt;displayName&gt;
+  &lt;sameAs.../&gt;
 &lt;/etymonLanguage&gt;
 </programlisting>
     </example>
@@ -57,7 +62,8 @@
         <programlisting>
 {
   "langCode": "..." ,
-  "displayName": "..."
+  "displayName": "...",
+  "sameAs": [ ... ]
 }
 </programlisting>
     </example>
@@ -66,7 +72,8 @@
         <title>RDF</title>
         <programlisting>
 &lt;#etymonLanguage&gt; dmlex:langCode "..." ;
-  dmlex:displayName "... "  .
+  dmlex:displayName "... "  ;
+  dmlex:sameAs ... .
 </programlisting>
     </example>
 

--- a/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonLanguage.xml
+++ b/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonLanguage.xml
@@ -33,7 +33,7 @@
         language, in the language of the lexicographic resource.</para>
     </listitem>
     <listitem>
-      <para><literal><olink targetptr="linking_sameAs">sameAs</olink></literal>
+      <para><literal><olink targetptr="etymology_sameAs">sameAs</olink></literal>
         <glossterm>optional</glossterm> (zero or more).</para>
     </listitem>
   </itemizedlist>

--- a/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonType.xml
+++ b/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonType.xml
@@ -32,7 +32,7 @@
                 explanation of this type.</para>
         </listitem>
         <listitem>
-            <para><literal><olink targetptr="linking_sameAs">sameAs</olink></literal>
+            <para><literal><olink targetptr="etymology_sameAs">sameAs</olink></literal>
                 <glossterm>optional</glossterm> (zero or more).</para>
         </listitem>
     </itemizedlist>

--- a/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonType.xml
+++ b/dmlex-v1.0/specification/modules/etymology/objectTypes/etymonType.xml
@@ -31,6 +31,10 @@
                 <glossterm>optional</glossterm> (zero or one). Normalised string. A human-readable
                 explanation of this type.</para>
         </listitem>
+        <listitem>
+            <para><literal><olink targetptr="linking_sameAs">sameAs</olink></literal>
+                <glossterm>optional</glossterm> (zero or more).</para>
+        </listitem>
     </itemizedlist>
     
     <example>

--- a/dmlex-v1.0/specification/modules/etymology/specification.xml
+++ b/dmlex-v1.0/specification/modules/etymology/specification.xml
@@ -20,5 +20,6 @@
   <xi:include href="objectTypes/etymonType.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/> 
   <xi:include href="objectTypes/etymonLanguage.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/> 
   <xi:include href="extensions/partOfSpeech.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/> 
+  <xi:include href="extensions/sameAs.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/> 
   
 </section>

--- a/dmlex-v1.0/specification/schemas/JSON/dmlex.schema.json
+++ b/dmlex-v1.0/specification/schemas/JSON/dmlex.schema.json
@@ -950,6 +950,13 @@
         "description": {
           "type": "string",
           "minLength": 1
+        },
+        "sameAs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sameAs"
+          },
+          "uniqueItems": true
         }
       },
       "additionalProperties": false
@@ -963,6 +970,13 @@
         },
         "displayName": {
           "type": "string"
+        },
+        "sameAs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sameAs"
+          },
+          "uniqueItems": true
         }
       },
       "additionalProperties": false

--- a/dmlex-v1.0/specification/schemas/JSON/dmlex.schema.json
+++ b/dmlex-v1.0/specification/schemas/JSON/dmlex.schema.json
@@ -906,9 +906,6 @@
             "$ref": "#/$defs/etymonUnit"
           },
           "minItems": 1
-        },
-        "translation": {
-          "type": "string"
         }
       },
       "additionalProperties": false

--- a/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
+++ b/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
@@ -709,11 +709,7 @@
             "$ref": "#/$defs/etymonUnit"
           },
           "minItems": 1
-        },
-        "translation": {
-          "type": "string"
-        }
-      },
+        }      },
       "additionalProperties": false
     },
     "etymonUnit": {
@@ -735,6 +731,9 @@
             "$ref": "#/$defs/partOfSpeech"
           },
           "uniqueItems": true
+        ,
+        "translation": {
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
+++ b/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
@@ -735,9 +735,6 @@
             "$ref": "#/$defs/partOfSpeech"
           },
           "uniqueItems": true
-        },
-        "translation": {
-          "type": "string"
         }
       },
       "additionalProperties": false

--- a/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
+++ b/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
@@ -753,6 +753,13 @@
         "description": {
           "type": "string",
           "minLength": 1
+        },
+        "sameAs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sameAs"
+          },
+          "uniqueItems": true
         }
       },
       "additionalProperties": false
@@ -766,6 +773,13 @@
         },
         "displayName": {
           "type": "string"
+        },
+        "sameAs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sameAs"
+          },
+          "uniqueItems": true
         }
       },
       "additionalProperties": false

--- a/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
+++ b/dmlex-v1.0/specification/schemas/JSON/dmlex_no-crosslingual.schema.json
@@ -731,7 +731,7 @@
             "$ref": "#/$defs/partOfSpeech"
           },
           "uniqueItems": true
-        ,
+        },
         "translation": {
           "type": "string"
         }

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-etymology.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-etymology.ttl
@@ -49,9 +49,6 @@ dmlex:Etymon a owl:Class ;
     a owl:Restriction ;
     owl:onProperty dmlex:etymonUnit ;
     owl:minCardinality 1 ] , [
-    a owl:Restriction ;
-    owl:onProperty dmlex:translation ;
-    owl:maxCardinality 1 ] , [
      a owl:Restriction ;
     owl:onProperty dmlex:listingOrder ;
     owl:cardinality 1 ] .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex-etymology.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex-etymology.ttl
@@ -140,3 +140,7 @@ dmlex:displayName a owl:ObjectProperty ;
   rdfs:label "Display Name"@en ;
   rdfs:domain dmlex:EtymonLanguage ;
   rdfs:range xsd:string .
+
+
+dmlex:EtymonLanguage rdfs:subClassOf dmlex:HasSameAs .
+dmlex:EtymonType rdfs:subClassOf dmlex:HasSameAs .

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex.ttl
@@ -990,3 +990,7 @@ dmlex:displayName a owl:ObjectProperty ;
   rdfs:label "Display Name"@en ;
   rdfs:domain dmlex:EtymonLanguage ;
   rdfs:range xsd:string .
+
+dmlex:EtymonLanguage rdfs:subClassOf dmlex:HasSameAs .
+dmlex:EtymonType rdfs:subClassOf dmlex:HasSameAs .
+

--- a/dmlex-v1.0/specification/schemas/RDF/dmlex.ttl
+++ b/dmlex-v1.0/specification/schemas/RDF/dmlex.ttl
@@ -926,7 +926,6 @@ dmlex:translation a owl:DatatypeProperty ;
   rdfs:domain dmlex:HasTranslation ;
   rdfs:range xsd:string .
 
-dmlex:Etymon rdfs:subClassOf dmlex:HasTranslation .
 dmlex:EtymonUnit rdfs:subClassOf dmlex:HasTranslation .
 
 dmlex:EtymonUnit a owl:Class ;

--- a/dmlex-v1.0/specification/schemas/XML/dmlex.xsd
+++ b/dmlex-v1.0/specification/schemas/XML/dmlex.xsd
@@ -642,7 +642,6 @@ It might be possible to re-write them as <assert>s using concatenation of values
     <xs:sequence>
       <xs:element name="note" minOccurs="0" type="xs:string"/>
       <xs:element ref="etymonUnit" maxOccurs="unbounded"/>
-      <xs:element name="translation" minOccurs="0" type="xs:string"/>
     </xs:sequence>
     <xs:attribute name="when" use="optional" type="xs:string"/>
     <xs:attribute name="type" use="optional" type="xs:string"/>

--- a/dmlex-v1.0/specification/schemas/XML/dmlex.xsd
+++ b/dmlex-v1.0/specification/schemas/XML/dmlex.xsd
@@ -667,6 +667,7 @@ It might be possible to re-write them as <assert>s using concatenation of values
   <xs:complexType name="etymonTypeType">
     <xs:sequence>
       <xs:element name="description" minOccurs="0" type="nonEmptyString"/>
+      <xs:element ref="sameAs" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="type" use="required" type="nonEmptyString"/>
   </xs:complexType>
@@ -676,6 +677,7 @@ It might be possible to re-write them as <assert>s using concatenation of values
   <xs:complexType name="etymonLanguageType">
     <xs:sequence>
       <xs:element name="displayName" minOccurs="0" type="xs:string"/>
+      <xs:element ref="sameAs" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="langCode" use="required" type="xs:language"/>
   </xs:complexType>

--- a/dmlex-v1.0/specification/schemas/XML/dmlex_no-crosslingual.xsd
+++ b/dmlex-v1.0/specification/schemas/XML/dmlex_no-crosslingual.xsd
@@ -527,7 +527,6 @@ It might be possible to re-write them as <assert>s using concatenation of values
     <xs:sequence>
       <xs:element name="note" minOccurs="0" type="xs:string"/>
       <xs:element ref="etymonUnit" maxOccurs="unbounded"/>
-      <xs:element name="translation" minOccurs="0" type="xs:string"/>
     </xs:sequence>
     <xs:attribute name="when" use="optional" type="xs:string"/>
     <xs:attribute name="type" use="optional" type="xs:string"/>

--- a/dmlex-v1.0/specification/schemas/XML/dmlex_no-crosslingual.xsd
+++ b/dmlex-v1.0/specification/schemas/XML/dmlex_no-crosslingual.xsd
@@ -552,6 +552,7 @@ It might be possible to re-write them as <assert>s using concatenation of values
   <xs:complexType name="etymonTypeType">
     <xs:sequence>
       <xs:element name="description" minOccurs="0" type="nonEmptyString"/>
+      <xs:element ref="sameAs" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="type" use="required" type="nonEmptyString"/>
   </xs:complexType>
@@ -561,6 +562,7 @@ It might be possible to re-write them as <assert>s using concatenation of values
   <xs:complexType name="etymonLanguageType">
     <xs:sequence>
       <xs:element name="displayName" minOccurs="0" type="xs:string"/>
+      <xs:element ref="sameAs" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="langCode" use="required" type="xs:language"/>
   </xs:complexType>

--- a/dmlex-v1.0/specification/serializations/JSON/objects/etymon.xml
+++ b/dmlex-v1.0/specification/serializations/JSON/objects/etymon.xml
@@ -29,10 +29,6 @@
                 <glossterm>required</glossterm>, array of one or more <literal><olink
                     targetptr="json_etymonUnit">etymonUnit</olink></literal> instances</para>
         </listitem>
-        <listitem>
-            <para><literal>"translation"</literal>
-                <glossterm>optional</glossterm>, string</para>
-        </listitem>
     </itemizedlist>
 
 </section>

--- a/dmlex-v1.0/specification/serializations/JSON/objects/etymonLanguage.xml
+++ b/dmlex-v1.0/specification/serializations/JSON/objects/etymonLanguage.xml
@@ -20,6 +20,11 @@
             <para><literal>"displayName"</literal>
                 <glossterm>optional</glossterm>, string</para>
         </listitem>
+        <listitem>
+            <para><literal>"sameAs"</literal>
+                <glossterm>optional</glossterm>, array of zero or more strings implementing the
+                <olink targetptr="values_sameAs">sameAs</olink> object type</para>
+        </listitem>
     </itemizedlist>
 
 </section>

--- a/dmlex-v1.0/specification/serializations/JSON/objects/etymonType.xml
+++ b/dmlex-v1.0/specification/serializations/JSON/objects/etymonType.xml
@@ -20,6 +20,11 @@
             <para><literal>"description"</literal>
                 <glossterm>optional</glossterm>, string</para>
         </listitem>
+        <listitem>
+            <para><literal>"sameAs"</literal>
+                <glossterm>optional</glossterm>, array of zero or more strings implementing the
+                <olink targetptr="values_sameAs">sameAs</olink> object type</para>
+        </listitem>
     </itemizedlist>
 
 </section>

--- a/dmlex-v1.0/specification/serializations/NVH/nodes/etymon.xml
+++ b/dmlex-v1.0/specification/serializations/NVH/nodes/etymon.xml
@@ -23,9 +23,6 @@
         <listitem>
             <para><literal><olink targetptr="nvh_etymonUnit">etymonUnit</olink></literal> <glossterm>required</glossterm> (one or more)</para>
         </listitem>
-        <listitem>
-            <para><literal>translation</literal> <glossterm>optional</glossterm> (zero or one)</para>
-        </listitem>
     </itemizedlist>
     
     

--- a/dmlex-v1.0/specification/serializations/NVH/nodes/etymonLanguage.xml
+++ b/dmlex-v1.0/specification/serializations/NVH/nodes/etymonLanguage.xml
@@ -21,6 +21,9 @@
         <listitem>
             <para><literal>displayName</literal> <glossterm>optional</glossterm> (zero or one)</para>
         </listitem>
+        <listitem>
+            <para><literal><olink targetptr="nvh_sameAs">sameAs</olink></literal> <glossterm>optional</glossterm> (zero or more)</para>
+        </listitem>
     </itemizedlist>
     
     

--- a/dmlex-v1.0/specification/serializations/NVH/nodes/etymonType.xml
+++ b/dmlex-v1.0/specification/serializations/NVH/nodes/etymonType.xml
@@ -21,6 +21,9 @@
         <listitem>
             <para><literal>description</literal> <glossterm>optional</glossterm> (zero or one)</para>
         </listitem>
+        <listitem>
+            <para><literal><olink targetptr="nvh_sameAs">sameAs</olink></literal> <glossterm>optional</glossterm> (zero or more)</para>
+        </listitem>
     </itemizedlist>
     
     

--- a/dmlex-v1.0/specification/serializations/RDB/tables/etymons.xml
+++ b/dmlex-v1.0/specification/serializations/RDB/tables/etymons.xml
@@ -33,9 +33,6 @@
             <para><literal>note: nvarchar</literal></para>
         </listitem>
         <listitem>
-            <para><literal>translation: nvarchar</literal></para>
-        </listitem>
-        <listitem>
             <para><literal>listingOrder: int</literal></para>
         </listitem>
     </itemizedlist>

--- a/dmlex-v1.0/specification/serializations/RDF/elements/Etymon.xml
+++ b/dmlex-v1.0/specification/serializations/RDF/elements/Etymon.xml
@@ -28,9 +28,6 @@
     <listitem>
         <para><literal>dmlex:etymonUnit</literal> REQUIRED (at least 1) reference to <olink targetptr="rdf_EtymonUnit">EtymonUnit</olink></para>
     </listitem>
-    <listitem>
-        <para><literal>dmlex:translation</literal> OPTIONAL (at most 1) of type <literal>http://www.w3.org/2001/XMLSchema#string</literal></para>
-    </listitem>
     </itemizedlist>
 
 

--- a/dmlex-v1.0/specification/serializations/RDF/elements/EtymonLanguage.xml
+++ b/dmlex-v1.0/specification/serializations/RDF/elements/EtymonLanguage.xml
@@ -19,6 +19,9 @@
     <listitem>
         <para><literal>dmlex:displayName</literal> OPTIONAL (at most 1) of type <literal>http://www.w3.org/2001/XMLSchema#string</literal></para>
     </listitem>
+    <listitem>
+        <para><literal>dmlex:sameAs</literal> OPTIONAL</para>
+    </listitem>
     </itemizedlist>
 
 

--- a/dmlex-v1.0/specification/serializations/RDF/elements/EtymonType.xml
+++ b/dmlex-v1.0/specification/serializations/RDF/elements/EtymonType.xml
@@ -19,6 +19,9 @@
     <listitem>
         <para><literal>dmlex:type</literal> REQUIRED (exactly 1) of type <literal>http://www.w3.org/2001/XMLSchema#string</literal></para>
     </listitem>
+    <listitem>
+        <para><literal>dmlex:sameAs</literal> OPTIONAL</para>
+    </listitem>
     </itemizedlist>
 
 

--- a/dmlex-v1.0/specification/serializations/XML/elements/etymon.xml
+++ b/dmlex-v1.0/specification/serializations/XML/elements/etymon.xml
@@ -27,9 +27,6 @@
         <listitem>
             <para><literal><olink targetptr="xml_etymonUnit">&lt;etymonUnit&gt;</olink></literal> <glossterm>required</glossterm> (one or more)</para>
         </listitem>
-        <listitem>
-            <para><literal>&lt;translation&gt;</literal> <glossterm>optional</glossterm> (zero or one)</para>
-        </listitem>
     </itemizedlist>
     
     

--- a/dmlex-v1.0/specification/serializations/XML/elements/etymonLanguage.xml
+++ b/dmlex-v1.0/specification/serializations/XML/elements/etymonLanguage.xml
@@ -21,6 +21,9 @@
         <listitem>
             <para><literal>&lt;displayName&gt;</literal> <glossterm>optional</glossterm> (zero or one)</para>
         </listitem>
+        <listitem>
+            <para><literal><olink targetptr="xml_sameAs">&lt;sameAs&gt;</olink></literal> <glossterm>optional</glossterm> (zero or more)</para>
+        </listitem>
     </itemizedlist>
     
     

--- a/dmlex-v1.0/specification/serializations/XML/elements/etymonType.xml
+++ b/dmlex-v1.0/specification/serializations/XML/elements/etymonType.xml
@@ -21,6 +21,9 @@
         <listitem>
             <para><literal>&lt;description&gt;</literal> <glossterm>optional</glossterm> (zero or one)</para>
         </listitem>
+        <listitem>
+            <para><literal><olink targetptr="xml_sameAs">&lt;sameAs&gt;</olink></literal> <glossterm>optional</glossterm> (zero or more)</para>
+        </listitem>
     </itemizedlist>
     
     


### PR DESCRIPTION
Implements the following changes
* Add `sameAs` to `etymonLanguage` and `etymonType`
* Remove `translation` from `etymon`

@michmech I did not manage to update the RDB diagrams. Could you do this please?