### PR TITLE
Editorial fixes

### DIFF
--- a/dmlex-v1.0/specification/ReviewChangeTracking/csd01.xml
+++ b/dmlex-v1.0/specification/ReviewChangeTracking/csd01.xml
@@ -8,8 +8,8 @@
 <title>Tracking of changes in response to the 1st Public Review</title>
 <para>This section tracks major changes made to this specification compared to the Committee
         Specification Draft 01 <ulink
-            url="&previous-loc;/&name;-&pstage;.pdf"
-            >&previous-loc;/&name;-&pstage;.pdf</ulink>.
+            url="https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd01/dmlex-v1.0-csd01.pdf.pdf"
+            >https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd01/dmlex-v1.0-csd01.pdf</ulink>.
         The initial Public Review took place from 22nd September 2023 until 17th November 2023.</para>
 <orderedlist>
 <!-- Add new change track items to the bottom of the list -->

--- a/dmlex-v1.0/specification/ReviewChangeTracking/csd02.xml
+++ b/dmlex-v1.0/specification/ReviewChangeTracking/csd02.xml
@@ -8,8 +8,8 @@
 <title>Tracking of changes in response to the 2nd Public Review</title>
     <para>This section tracks major changes made to this specification compared to the Committee
         Specification Draft 02 <ulink
-            url="&previous-loc;/&name;-&pstage;.pdf"
-            >&previous-loc;/&name;-&pstage;.pdf</ulink>.
+            url="https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd02/dmlex-v1.0-csd02.pdf"
+            >https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd02/dmlex-v1.0-csd02.pdf</ulink>.
         The second Public Review took place from 31st January 2024 until 29th February 2024.</para>
     <orderedlist>
 

--- a/dmlex-v1.0/specification/ReviewChangeTracking/csd03.xml
+++ b/dmlex-v1.0/specification/ReviewChangeTracking/csd03.xml
@@ -8,107 +8,15 @@
 <title>Tracking of changes in response to the 3rd Public Review</title>
 <para>This section tracks all changes made to this specification compared to the Committee
         Specification Draft 03 / Public Review Draft 03 <ulink
-            url="http://docs.oasis-open.org/xliff/xliff-core/v2.1/csprd03/xliff-core-v2.1-csprd03.html"
-            >http://docs.oasis-open.org/xliff/xliff-core/v2.1/csprd03/xliff-core-v2.1-csprd03.html</ulink>.
-        This subsequent Public Review took place from 17th April 2017 until 1st May 2017.</para>
+            url="https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd03/dmlex-v1.0-csd03.pdf"
+            >https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd03/dmlex-v1.0-csd03.pdf</ulink>.
+        The 3rd public review took place from 28th June 2024 until 27th July 2024.</para>
 <orderedlist>
 <!-- Add new change track items to the bottom of the list -->
-<!-- 
-    <listitem>
-    <para>Major changes were made in the ITS Module and validation artifacts in response to
-        Comment/Issues <ulink url="https://issues.oasis-open.org/browse/XLIFF-5">https://issues.oasis-open.org/browse/XLIFF-5</ulink> and most importantly <ulink url="https://issues.oasis-open.org/browse/XLIFF-9"
-                    >https://issues.oasis-open.org/browse/XLIFF-9</ulink> and its child issues:
-                    <ulink url="https://issues.oasis-open.org/browse/XLIFF-6"
-                    >https://issues.oasis-open.org/browse/XLIFF-6</ulink>, <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-18"
-                    >https://issues.oasis-open.org/browse/XLIFF-18</ulink>, and <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-19"
-                    >https://issues.oasis-open.org/browse/XLIFF-19</ulink>. </para>
-</listitem>
-        <listitem>
-            <para>Major changes were made in the Change Tracking Module and validation artifacts in
-                response to Comment/Issue <ulink url="https://issues.oasis-open.org/browse/XLIFF-4">https://issues.oasis-open.org/browse/XLIFF-4</ulink></para>
-        </listitem>
-        <listitem>
-            <para>Clarifications to Core with Advanced Validation impact, non-of which were
-                normative changes were provided in response to Comments/Issues: 
-                <ulink url="https://issues.oasis-open.org/browse/XLIFF-10">https://issues.oasis-open.org/browse/XLIFF-10</ulink>,
-                <ulink url="https://issues.oasis-open.org/browse/XLIFF-11">https://issues.oasis-open.org/browse/XLIFF-11</ulink>,
-                <ulink url="https://issues.oasis-open.org/browse/XLIFF-12">https://issues.oasis-open.org/browse/XLIFF-12</ulink>,
-                <ulink url="https://issues.oasis-open.org/browse/XLIFF-13">https://issues.oasis-open.org/browse/XLIFF-13</ulink>,
-                <ulink url="https://issues.oasis-open.org/browse/XLIFF-14">https://issues.oasis-open.org/browse/XLIFF-14</ulink>
-                
-                
-            </para>
-        </listitem>
-        <listitem>
-            <para>Material clarification with Advanced Validation Impact was provided for the
-                Translation Candidate Module in response to Issue <ulink url="https://issues.oasis-open.org/browse/XLIFF-20">https://issues.oasis-open.org/browse/XLIFF-20</ulink>.</para>
-        </listitem> -->
         
         <listitem>
-            <para>Major bug fix of the core Schematron Schema has been made in response to
-                Comment/Issue <ulink url="https://issues.oasis-open.org/browse/XLIFF-48"
-                    >https://issues.oasis-open.org/browse/XLIFF-48</ulink>. The core Schematron now
-                enforces that non-reorderable sequences start with a code with
-                    <code>canReorder</code> set to <code>firstNo</code> and also enforces the
-                repetition of non-reorderable sequences in <code>&lt;target></code> elements. In
-                connection with this issue, issues <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-10"
-                    >https://issues.oasis-open.org/browse/XLIFF-10</ulink> and <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-11"
-                    >https://issues.oasis-open.org/browse/XLIFF-11</ulink> were reopened and changes
-                in core Schematron made to ensure that the rules for enforcing of editing hints
-                compliance in <code>target</code> elements worked properly in concert with reporting
-                of invalid <code>&lt;segment></code>
-                <code>state</code>.</para>
-        </listitem>
-        <listitem>
-            <para>Another major bug fix was due reopened <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-38"
-                    >https://issues.oasis-open.org/browse/XLIFF-38</ulink>, validation methods had
-                to be adjusted for core and core reused in modules in the NVDL.</para>
-        </listitem>
-        <listitem>
-            <para>An erroneously omitted Constraint of the <olink
-                    targetdoc="../attributes/xml_lang.xml" targetptr="xml_lang"
-                        ><code>xml:lang</code></olink> attribute on the <olink targetptr="source"
-                    targetdoc="../elements/structural/source.xml"><code>&lt;source></code></olink>
-                element has be added/restored in the normative text and check therefore introduced
-                in the Core Schematron Schema in response to Issue/Comment <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-55"
-                    >https://issues.oasis-open.org/browse/XLIFF-55</ulink>.</para>
-        </listitem>
-        <listitem>
-            <para><code>its:version</code> attribute was introduced in response to Issue/Comment <ulink
-                url="https://issues.oasis-open.org/browse/XLIFF-54"
-                >https://issues.oasis-open.org/browse/XLIFF-54</ulink>.</para>
-        </listitem>
-        <listitem>
-            <para>Due to reopening of <ulink url="https://issues.oasis-open.org/browse/XLIFF-38"
-                    >https://issues.oasis-open.org/browse/XLIFF-8</ulink>, mapping of
-                <code>locQualityRatingScore</code> was removed from <code>matchQuality</code>. This eased the implementation
-                of both ITS MT Confidence end Localization Quality Rating considerably.</para>
-        </listitem>
-        <listitem>
-            <para>Changes were made to validation of <code>annotatorsRef</code> attribute in
-                response to Issue/Comment <ulink url="https://issues.oasis-open.org/browse/XLIFF-52"
-                    >https://issues.oasis-open.org/browse/XLIFF-52</ulink>. Examples using
-                    <code>annotatorsRef</code> had be reformatted not to suggest a wrong
-                interpretation of the attribute.</para>
-        </listitem>
-        <listitem>
-            <para>Editorial fixes were made in response to Comments/Issues: <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-47"
-                    >https://issues.oasis-open.org/browse/XLIFF-47</ulink>, <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-50"
-                    >https://issues.oasis-open.org/browse/XLIFF-50</ulink>, <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-51"
-                    >https://issues.oasis-open.org/browse/XLIFF-51</ulink>, <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-53"
-                    >https://issues.oasis-open.org/browse/XLIFF-53</ulink> and <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-56"
-                    >https://issues.oasis-open.org/browse/XLIFF-56</ulink>.</para>
+            <para>Editorial error corrections were made in response to OASIS Admin csd03
+                comments (Github issue <ulink url="https://github.com/oasis-tcs/lexidma/issues/134">134</ulink>.</para>
         </listitem>
                     
                 

--- a/dmlex-v1.0/specification/ReviewChangeTracking/csd04.xml
+++ b/dmlex-v1.0/specification/ReviewChangeTracking/csd04.xml
@@ -4,47 +4,23 @@
 %xinclude;
 <!ENTITY % local.common.attrib "xml:base CDATA #IMPLIED">
 ]>
-<section id="csprd04">
-<title>Tracking of changes in response to the 4th Public Review</title>
+<section id="csprd03">
+<title>Tracking of changes in response to the 3rd Public Review</title>
 <para>This section tracks all changes made to this specification compared to the Committee
-        Specification Draft 04 / Public Review Draft 04 <ulink
-            url="http://docs.oasis-open.org/xliff/xliff-core/v2.1/csprd04/xliff-core-v2.1-csprd04.html"
-            >http://docs.oasis-open.org/xliff/xliff-core/v2.1/csprd04/xliff-core-v2.1-csprd04.html</ulink>.
-        This subsequent Public Review took place from 5th June 2017 until 20th June 2017.</para>
+        Specification Draft 03 / Public Review Draft 03 <ulink
+            url="https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd03/dmlex-v1.0-csd03.pdf"
+            >https://docs.oasis-open.org/lexidma/dmlex/v1.0/csd03/dmlex-v1.0-csd03.pdf</ulink>.
+        The 3rd public review took place from 28th June 2024 until 27th July 2024.</para>
 <orderedlist>
 <!-- Add new change track items to the bottom of the list -->
         
         <listitem>
-            <para>Xpath expressions have been fixed in ITS Rules in response to
-                Comment/Issue <ulink url="https://issues.oasis-open.org/browse/XLIFF-58"
-                    >https://issues.oasis-open.org/browse/XLIFF-58</ulink>.</para>
+            <para>Only editorial error corrections were made in response to OASIS Admin csd03
+                comments (Github issue <ulink url="https://github.com/oasis-tcs/lexidma/issues/134">134</ulink>.</para>
         </listitem>
-        <listitem>
-            <para>Minor editorial fixes and improvements were made in response to Comments/Issues <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-57"
-                >https://issues.oasis-open.org/browse/XLIFF-57</ulink>, <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-62"
-                    >https://issues.oasis-open.org/browse/XLIFF-62</ulink>, <ulink
-                        url="https://issues.oasis-open.org/browse/XLIFF-63"
-                        >https://issues.oasis-open.org/browse/XLIFF-63</ulink>, <ulink
-                            url="https://issues.oasis-open.org/browse/XLIFF-64"
-                            >https://issues.oasis-open.org/browse/XLIFF-64</ulink>, <ulink
-                                url="https://issues.oasis-open.org/browse/XLIFF-65"
-                                >https://issues.oasis-open.org/browse/XLIFF-65</ulink>, <ulink
-                                    url="https://issues.oasis-open.org/browse/XLIFF-66"
-                                    >https://issues.oasis-open.org/browse/XLIFF-66</ulink>, and <ulink
-                                        url="https://issues.oasis-open.org/browse/XLIFF-70"
-                                        >https://issues.oasis-open.org/browse/XLIFF-70</ulink>.</para>
-        </listitem>
-        <listitem>
-            <para>Trivial editorial fixes and improvements  were made in response to Comments/Issues <ulink
-                url="https://issues.oasis-open.org/browse/XLIFF-59"
-                >https://issues.oasis-open.org/browse/XLIFF-59</ulink>, <ulink
-                    url="https://issues.oasis-open.org/browse/XLIFF-60"
-                    >https://issues.oasis-open.org/browse/XLIFF-60</ulink>, and <ulink
-                        url="https://issues.oasis-open.org/browse/XLIFF-61"
-                        >https://issues.oasis-open.org/browse/XLIFF-61</ulink>.</para>
-        </listitem>
+                    
+                
+                
                 
                
 

--- a/dmlex-v1.0/specification/dmlex.xml
+++ b/dmlex-v1.0/specification/dmlex.xml
@@ -121,7 +121,8 @@
 	<para>Informative copies of third party schemas are provided:</para>
 	<para><ulink url="&this-loc;/schemas/informativeCopiesOf3rdPartySchemas/">&this-loc;/schemas/informativeCopiesOf3rdPartySchemas/</ulink></para>
     </legalnotice>
-    <legalnotice role="related">
+    <!--  Commenting out the Related Work notice as requested by OASIS Admin, see https://github.com/oasis-tcs/lexidma/issues/134  
+      <legalnotice role="related">
       <title>Related Work</title>
       <!-- Model content for replaced specifications in the future
    <para>This specification replaces or supersedes:</para>
@@ -132,7 +133,7 @@
             05 August 2014. OASIS Standard. <ulink url="http://docs.oasis-open.org/xliff/xliff-core/v2.0/os/xliff-core-v2.0-os.html">http://docs.oasis-open.org/xliff/xliff-core/v&pversion;/os/xliff-core-v&pversion;-os.html</ulink></para>
         </listitem>
       </itemizedlist>
-      -->
+      ->
       <para>This specification is related to:</para>
       <itemizedlist spacing="compact">
         <!-- model content for related specifications in case there are any later on
@@ -150,12 +151,12 @@
               url="http://docs.oasis-open.org/xliff/xliff-core/v2.1/os/xliff-core-v2.1-os.html"
               >http://docs.oasis-open.org/xliff/xliff-core/v2.1/os/xliff-core-v2.1-os.html</ulink></para>
         </listitem>
-        -->
+        ->
         <listitem>
           <para><emphasis>No related specifications.</emphasis></para>
         </listitem>
       </itemizedlist>
-    </legalnotice>
+    </legalnotice>-->
     <legalnotice id="namespaces" role="namespaces">
       <title>Declared namespaces</title>
       <para>This specification declares one or more namespaces. Namespace isn't considered an XML
@@ -249,7 +250,7 @@
       <para>When referencing this specification the following citation format should be used:</para>
       <para><citation>DMLex-&version;</citation></para>
       <para><emphasis>Data Model for Lexicography Version &version;</emphasis>. Edited by David
-        Filip, Miloš Jakubíček, Simon Krek, John McCrae, and Michal Měchura. &pubdate;. OASIS
+        Filip, Miloš Jakubíček, Vojtěch Kovář, Simon Krek, John McCrae, and Michal Měchura. &pubdate;. OASIS
         &standard;. <ulink url="&this-loc;/&name;-&stage;.html"
           >&this-loc;/&name;-&stage;.html</ulink>. Latest version: <ulink
           url="&latest-loc;/&name;.html">&latest-loc;/&name;.html</ulink>. </para>
@@ -262,11 +263,11 @@
     <legalnotice role="notices">
       <title>Notices</title>
       <para>Copyright © OASIS Open &pubyear;.</para>
-      <para>All Rights Reserved.Distributed under the terms of the OASIS <ulink
+      <para>All Rights Reserved. Distributed under the terms of the OASIS <ulink
           url="https://www.oasis-open.org/policies-guidelines/ipr/"
-        >IPR Policy</ulink>).</para>
+        >IPR Policy</ulink>.</para>
       <para>The name "OASIS" is a trademark of <ulink url="https://www.oasis-open.org/"
-        >OASIS</ulink>), the owner and developer of this specification, and
+        >OASIS</ulink>, the owner and developer of this specification, and
         should be used only to refer to the organization and its official outputs.</para>
       <para>For complete copyright information please see the <link linkend="full-notices">full Notices</link> section in an Appendix
         below.</para>
@@ -773,10 +774,11 @@
           <citetitle><ulink url="http://www.w3.org/2001/xml.xsd"
               >http://www.w3.org/2001/xml.xsd</ulink></citetitle> [<edition><ulink
               url="http://www.w3.org/2009/01/xml.xsd"
-            >http://www.w3.org/2009/01/xml.xsd</ulink>]</edition>. at <edition><ulink
+            >http://www.w3.org/2009/01/xml.xsd</ulink>]</edition>. <!-- at <edition><ulink
               url="&this-loc;/schemas/informativeCopiesOf3rdPartySchemas/w3c/xml.xsd"
               >&this-loc;/schemas/informativeCopiesOf3rdPartySchemas/w3c/xml.xsd</ulink></edition>
-          in this distribution</bibliomixed>
+          in this distribution-->
+        </bibliomixed>
         <bibliomixed id="XMLCatalogs"><abbrev>XML Catalogs</abbrev> Norman Walsh, <title>XML
             Catalogs</title>, <citetitle>
             <ulink url="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html"

--- a/dmlex-v1.0/specification/docbook/dbgenent.mod
+++ b/dmlex-v1.0/specification/docbook/dbgenent.mod
@@ -49,18 +49,18 @@
 <!ENTITY cschversion "1.0">
 
 
-<!ENTITY stage "csd03">
-<!ENTITY pstage "csd02">
+<!ENTITY stage "csd04">
+<!ENTITY pstage "csd03">
 <!--
 <!ENTITY standard "Committee Specification Draft 01">
 -->
-<!ENTITY standard "Committee Specification Draft 03">
+<!ENTITY standard "Committee Specification draft 04">
 
 <!ENTITY this-loc "https://docs.oasis-open.org/lexidma/dmlex/v&version;/&stage;">
 <!ENTITY previous-loc "https://docs.oasis-open.org/lexidma/dmlex/v&version;/&pstage;">
 <!ENTITY latest-loc "https://docs.oasis-open.org/lexidma/dmlex/v&version;">
 
-<!ENTITY pubdate "12 June &pubyear;">
+<!ENTITY pubdate "06 September &pubyear;">
 
 <!ENTITY pubyear "2024">
 <!ENTITY releaseinfo "Standards Track Work Product">


### PR DESCRIPTION
- Advanced publishing entities to csd04 expected to progress on 6th Sep
- fixed links in csd01 and csd02 change tracking, added csd03 change tracking
- Fixed editorial issues 1-3, and 6 from https://github.com/oasis-tcs/lexidma/issues/134